### PR TITLE
Add fullscreen widget preview

### DIFF
--- a/pages/page_styles/explore.css
+++ b/pages/page_styles/explore.css
@@ -760,6 +760,118 @@ main {
     box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);
 }
 
+/* === FULLSCREEN PREVIEW MODAL === */
+.widget-fullscreen-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 10002;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+.fullscreen-inner {
+    width: 96vw;
+    height: 92vh;
+    background: var(--bg-secondary);
+    border: var(--border-width) solid var(--primary-neon);
+    border-radius: var(--border-radius);
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--shadow-glow);
+}
+
+.fullscreen-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    border-bottom: var(--border-width) solid var(--primary-neon);
+    background: var(--bg-tertiary);
+}
+
+.fullscreen-header h3 {
+    margin: 0;
+    color: var(--primary-neon);
+    font-family: "Orbitron", monospace;
+    font-size: 1rem;
+}
+
+.fullscreen-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.fullscreen-close-btn,
+.fullscreen-open-tab-btn {
+    background: var(--bg-secondary);
+    color: var(--primary-neon);
+    border: 2px solid var(--primary-neon);
+    border-radius: var(--border-radius);
+    width: 36px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.fullscreen-close-btn:hover,
+.fullscreen-open-tab-btn:hover {
+    background: var(--primary-neon);
+    color: var(--bg-primary);
+}
+
+.fullscreen-body {
+    flex: 1;
+    background: var(--bg-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.fullscreen-iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+.fullscreen-image,
+.fullscreen-video {
+    max-width: 100%;
+    max-height: 100%;
+}
+
+.preview-controls {
+    margin-top: 8px;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.preview-fullscreen-btn {
+    padding: 6px 10px;
+    background: var(--bg-tertiary);
+    border: 2px solid var(--primary-neon);
+    border-radius: var(--border-radius);
+    color: var(--primary-neon);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.preview-fullscreen-btn:hover {
+    background: var(--primary-neon);
+    color: var(--bg-primary);
+}
+
 /* === ACCESSIBILITY === */
 @media (prefers-reduced-motion: reduce) {
 


### PR DESCRIPTION
Add a fullscreen preview experience for uploaded widgets and files to enhance demo capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-59f90ac6-115a-4d1e-b551-ebbe4fcc52c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59f90ac6-115a-4d1e-b551-ebbe4fcc52c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

